### PR TITLE
hide the internal classes to the outside world

### DIFF
--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/BooleanPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/BooleanPref.kt
@@ -23,18 +23,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-
-class BooleanPref(
-    val key: String? = null,
-    val defaultValue: Boolean = false,
-    val preferences: SharedPreferences = MagicPref.sharePrefInstance
+internal class BooleanPref(
+    private val key: String? = null,
+    private val defaultValue: Boolean = false,
+    private val preferences: SharedPreferences = MagicPref.sharePrefInstance
 ): PrefProperty<Boolean>() {
     override fun getValueFromPref(property: KProperty<*>): Boolean {
-        return preferences.getBoolean(key, defaultValue)
+        return preferences.getBoolean(key ?: property.name, defaultValue)
     }
 
     override fun setValueToPref(property: KProperty<*>, value: Boolean) {
-        preferences.edit().putBoolean(key, value).apply()
+        preferences.edit().putBoolean(key ?: property.name, value).apply()
     }
 }
 

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/FloatPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/FloatPref.kt
@@ -24,10 +24,10 @@ limitations under the License.
  */
 
 
-class FloatPref(
-    val key: String? = null,
-    val defaultValue: Float = 0F,
-    val preferences: SharedPreferences? = MagicPref.sharePrefInstance
+internal class FloatPref(
+    private val key: String? = null,
+    private val defaultValue: Float = 0F,
+    private val preferences: SharedPreferences? = MagicPref.sharePrefInstance
 ) : PrefProperty<Float>() {
     override fun getValueFromPref(property: KProperty<*>): Float {
         return preferences?.getFloat(key ?: property.name, defaultValue)!!

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/IntPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/IntPref.kt
@@ -9,10 +9,10 @@ import kotlin.reflect.KProperty
  * MagicPref
  */
 
-class IntPref(
-    val key: String? = null,
-    val defaultValue: Int = 0,
-    val preferences: SharedPreferences? = MagicPref.sharePrefInstance
+internal class IntPref(
+    private val key: String? = null,
+    private val defaultValue: Int = 0,
+    private val preferences: SharedPreferences? = MagicPref.sharePrefInstance
 ): PrefProperty<Int>() {
     override fun getValueFromPref(property: KProperty<*>): Int {
         return preferences?.getInt(key ?: property.name, defaultValue)!!

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/LongPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/LongPref.kt
@@ -24,10 +24,10 @@ limitations under the License. https://github.com/chibatching/Kotpref
  */
 
 
-class LongPref(
-    val key: String? = null,
-    val defaultValue: Long = 0L,
-    val preferences: SharedPreferences = MagicPref.sharePrefInstance
+internal class LongPref(
+    private val key: String? = null,
+    private val defaultValue: Long = 0L,
+    private val preferences: SharedPreferences = MagicPref.sharePrefInstance
 ): PrefProperty<Long>() {
     override fun getValueFromPref(property: KProperty<*>): Long {
         return preferences.getLong(key ?: property.name, defaultValue)

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/MagicPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/MagicPref.kt
@@ -24,7 +24,7 @@ limitations under the License.
  */
 
 
-object MagicPref {
+internal object MagicPref {
     lateinit var sharePrefInstance: SharedPreferences
     private var mode = Context.MODE_PRIVATE
     private var prefFileName = javaClass.simpleName

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/MagicPrefInitProvider.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/MagicPrefInitProvider.kt
@@ -26,7 +26,7 @@ limitations under the License.
  */
 
 
-class MagicPrefInitProvider : ContentProvider() {
+internal class MagicPrefInitProvider : ContentProvider() {
     override fun onCreate(): Boolean {
         MagicPref.init(context!!)
         return true

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/SharedPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/SharedPref.kt
@@ -26,7 +26,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-object SharedPreferenceFactory {
+internal object SharedPreferenceFactory {
 
     fun newInstance(context: Context, fileName: String, prefMode: Int): SharedPreferences {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/magicpref/src/main/java/com/github/rygelouv/magicpref/StringPref.kt
+++ b/magicpref/src/main/java/com/github/rygelouv/magicpref/StringPref.kt
@@ -9,10 +9,10 @@ import kotlin.reflect.KProperty
  * MagicPref
  */
 
-class StringPref(
-    val key: String? = null,
-    val defaultValue: String? = "",
-    val preferences: SharedPreferences? = MagicPref.sharePrefInstance
+internal class StringPref(
+    private val key: String? = null,
+    private val defaultValue: String? = "",
+    private val preferences: SharedPreferences? = MagicPref.sharePrefInstance
 ): PrefProperty<String?>() {
     override fun getValueFromPref(property: KProperty<*>): String? {
         return preferences?.getString(key ?: property.name, defaultValue)

--- a/magicpref/src/test/java/com/github/rygelouv/magicpref/MagicPrefTest.kt
+++ b/magicpref/src/test/java/com/github/rygelouv/magicpref/MagicPrefTest.kt
@@ -31,9 +31,9 @@ class MagicPrefUnitTest {
     @Mock
     var mMockEditor: SharedPreferences.Editor? = null
 
-    lateinit var textPref: StringPref
-    lateinit var numberPref: IntPref
-    lateinit var floatNumberPref: FloatPref
+    internal lateinit var textPref: StringPref
+    internal lateinit var numberPref: IntPref
+    internal lateinit var floatNumberPref: FloatPref
 
 
     @Before


### PR DESCRIPTION
Users of this library should not be able to access classes like BooleanPref, FloatPref, etc.
Fix an issue to the BooleanPref where the user was able to provide a null key
Fix the test issue due to the modification of the visibility of some internal classes.