### PR TITLE
Update androidx security library, from  1.0.0-alpha02 to 1.1.0-alpha0

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-    implementation "androidx.security:security-crypto:1.0.0-alpha02"
+    implementation "androidx.security:security-crypto:1.1.0-alpha02"
 
     implementation project(path: ':magicpref')
 }


### PR DESCRIPTION
There was a crash in release mode caused by androidx security library, to fix it ii updated the library version from 1.0.0-alpha02 to 1.1.0-alpha0
The link of the android x library release note is here :  https://developer.android.com/jetpack/androidx/releases/security#1.1.0-alpha02